### PR TITLE
Distribution commands fixes

### DIFF
--- a/apptrust/commands/flags.go
+++ b/apptrust/commands/flags.go
@@ -126,7 +126,7 @@ var flagsMap = map[string]components.Flag{
 	CreateRepoFlag:                    components.NewBoolFlag(CreateRepoFlag, "Set to true to create the repository on the edge if it does not exist.", components.WithBoolDefaultValueFalse()),
 	MappingPatternFlag:                components.NewStringFlag(MappingPatternFlag, "Specify along with "+MappingTargetFlag+" to distribute artifacts to a different path on the edge node. You can use wildcards to specify multiple artifacts.", func(f *components.StringFlag) { f.Mandatory = false }),
 	MappingTargetFlag:                 components.NewStringFlag(MappingTargetFlag, "The target path for distributed artifacts on the edge node. If not specified, the artifacts will have the same path and name on the edge node, as on the source Artifactory server. For flexibility in specifying the distribution path, you can include placeholders in the form of {1}, {2} which are replaced by corresponding tokens in the pattern path that are enclosed in parenthesis.", func(f *components.StringFlag) { f.Mandatory = false }),
-	QuietFlag:                         components.NewBoolFlag(QuietFlag, "Set to true to skip the confirmation message.", components.WithBoolDefaultValueFalse()),
+	QuietFlag:                         components.NewBoolFlag(QuietFlag, "Set to true to skip the confirmation message. When $CI is true, the default value is true.", components.WithBoolDefaultValueFalse()),
 }
 
 var commandFlags = map[string][]string{

--- a/apptrust/commands/version/distribute_app_version_cmd.go
+++ b/apptrust/commands/version/distribute_app_version_cmd.go
@@ -116,6 +116,7 @@ Gotchas:
 
 Related: jf apptrust version-delete-remote, jf apptrust version-release`,
 		Category: common.CategoryVersion,
+		Aliases:  []string{"vdist"},
 		Arguments: []components.Argument{
 			{
 				Name:        "application-key",

--- a/apptrust/commands/version/remote_delete_app_version_cmd.go
+++ b/apptrust/commands/version/remote_delete_app_version_cmd.go
@@ -156,6 +156,7 @@ Gotchas:
 
 Related: jf apptrust version-distribute, jf apptrust version-delete`,
 		Category: common.CategoryVersion,
+		Aliases:  []string{"vdr"},
 		Arguments: []components.Argument{
 			{
 				Name:        "application-key",

--- a/apptrust/commands/version/remote_delete_app_version_cmd.go
+++ b/apptrust/commands/version/remote_delete_app_version_cmd.go
@@ -54,7 +54,7 @@ func (rd *remoteDeleteAppVersionCommand) prepareAndRunCommand(ctx *components.Co
 
 	rd.applicationKey = ctx.Arguments[0]
 	rd.version = ctx.Arguments[1]
-	rd.quiet = ctx.GetBoolFlagValue(commands.QuietFlag)
+	rd.quiet = pluginsCommon.GetQuietValue(ctx)
 
 	if err := ValidateDistributionFlags(ctx); err != nil {
 		return err

--- a/apptrust/commands/version/remote_delete_app_version_cmd_test.go
+++ b/apptrust/commands/version/remote_delete_app_version_cmd_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jfrog/jfrog-cli-application/apptrust/model"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -170,6 +171,8 @@ func TestRemoteDeleteAppVersionCommand_QuietSuite(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(coreutils.CI, "false")
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 


### PR DESCRIPTION
- [x] The pull request is targeting the `main` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-application/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-application/actions/workflows/tests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All [E2E tests](https://github.com/jfrog/jfrog-cli-application/actions/workflows/e2e-tests.yml) have passed.
- [x] All changes are detailed at the description.

-----
- Remotely delete quietly on CI pipelines.
- Add aliases to distribution commands.